### PR TITLE
Support for battery info and M5LED fix for M5Stickc plus2

### DIFF
--- a/m5stick-nemo.ino
+++ b/m5stick-nemo.ino
@@ -73,7 +73,6 @@ String buildver="2.3.4";
   #define SD_CLK_PIN 0
   #define SD_MISO_PIN 36
   #define SD_MOSI_PIN 26
-  #define BATTERY_MAX_VOLTAGE 3.7
   #define M5_LED_PIN 19
   #define M5_LED_ON HIGH
   #define M5_LED_OFF LOW
@@ -587,7 +586,7 @@ int rotation = 1;
 
 /// BATTERY INFO ///
 
-#if defined(PWRMGMT) && defined(BATTERY_MAX_VOLTAGE) 
+#if defined(PWRMGMT)
   int old_battery = 0;
 
   void battery_drawmenu(int battery) {
@@ -601,15 +600,7 @@ int rotation = 1;
   }
 
   int get_battery_voltage() {
-    int current_voltage = M5.Power.getBatteryVoltage() / 1000;
-    int battery_percentage = (current_voltage / BATTERY_MAX_VOLTAGE) * 100;
-
-    if (battery_percentage > 100)
-      return 100;
-    if (battery_percentage < 0)
-      return 0;
-
-    return battery_percentage;
+    return M5.Power.getBatteryLevel();
   }
 
   void battery_setup() {

--- a/m5stick-nemo.ino
+++ b/m5stick-nemo.ino
@@ -40,6 +40,8 @@ String buildver="2.3.4";
   #define SD_CLK_PIN 0
   #define SD_MISO_PIN 36
   #define SD_MOSI_PIN 26
+  #define M5LED_ON LOW
+  #define M5LED_OFF HIGH
 #endif
 
 #if defined(STICK_C_PLUS2)
@@ -70,6 +72,8 @@ String buildver="2.3.4";
   #define SD_CLK_PIN 0
   #define SD_MISO_PIN 36
   #define SD_MOSI_PIN 26
+  #define M5LED_ON HIGH
+  #define M5LED_OFF LOW
 #endif
 
 #if defined(STICK_C)
@@ -94,6 +98,8 @@ String buildver="2.3.4";
   #define SD_CLK_PIN 0
   #define SD_MISO_PIN 36
   #define SD_MOSI_PIN 26
+  #define M5LED_ON LOW
+  #define M5LED_OFF HIGH
 #endif
 
 #if defined(CARDPUTER)
@@ -1302,9 +1308,9 @@ void aj_adv(){
     pAdvertising->setAdvertisementData(oAdvertisementData);
     pAdvertising->start();
 #if defined(M5LED)
-    digitalWrite(IRLED, LOW); //LED ON on Stick C Plus
+    digitalWrite(IRLED, M5LED_ON); //LED ON on Stick C Plus
     delay(10);
-     digitalWrite(IRLED, HIGH); //LED OFF on Stick C Plus
+     digitalWrite(IRLED, M5LED_OFF); //LED OFF on Stick C Plus
 #endif
   }
   if (check_next_press()) {
@@ -1411,9 +1417,9 @@ void wifispam_loop() {
   int i = 0;
   int len = 0;
 #if defined(M5LED)
-  digitalWrite(IRLED, LOW); //LED ON on Stick C Plus
+  digitalWrite(IRLED, M5LED_ON); //LED ON on Stick C Plus
   delay(1);
-  digitalWrite(IRLED, HIGH); //LED OFF on Stick C Plus
+  digitalWrite(IRLED, M5LED_OFF); //LED OFF on Stick C Plus
 #endif
   currentTime = millis();
   if (currentTime - attackTime > 100) {
@@ -1797,7 +1803,7 @@ void setup() {
   // Pin setup
 #if defined(M5LED)
   pinMode(IRLED, OUTPUT);
-  digitalWrite(IRLED, M5_LED_OFF); //LEDOFF
+  digitalWrite(IRLED, M5LED_OFF); //LEDOFF
 #endif
 #if !defined(KB)
   pinMode(M5_BUTTON_HOME, INPUT);

--- a/m5stick-nemo.ino
+++ b/m5stick-nemo.ino
@@ -40,9 +40,6 @@ String buildver="2.3.4";
   #define SD_CLK_PIN 0
   #define SD_MISO_PIN 36
   #define SD_MOSI_PIN 26
-  #define M5_LED_PIN 10
-  #define M5_LED_ON LOW
-  #define M5_LED_OFF HIGH
 #endif
 
 #if defined(STICK_C_PLUS2)
@@ -73,9 +70,6 @@ String buildver="2.3.4";
   #define SD_CLK_PIN 0
   #define SD_MISO_PIN 36
   #define SD_MOSI_PIN 26
-  #define M5_LED_PIN 19
-  #define M5_LED_ON HIGH
-  #define M5_LED_OFF LOW
 #endif
 
 #if defined(STICK_C)
@@ -100,9 +94,6 @@ String buildver="2.3.4";
   #define SD_CLK_PIN 0
   #define SD_MISO_PIN 36
   #define SD_MOSI_PIN 26
-  #define M5_LED_PIN 10
-  #define M5_LED_ON LOW
-  #define M5_LED_OFF HIGH
 #endif
 
 #if defined(CARDPUTER)
@@ -133,7 +124,7 @@ String buildver="2.3.4";
 #endif
 
 // -=-=-=-=-=- LIST OF CURRENTLY DEFINED FEATURES -=-=-=-=-=-
-// M5LED      - An LED exposed as M5_LED_PIN
+// M5LED      - An LED exposed as IRLED
 // RTC        - Real-time clock exposed as M5.Rtc 
 // AXP        - AXP192 Power Management exposed as M5.Axp
 // PWRMGMT    - StickC+2 Power Management exposed as M5.Power
@@ -489,7 +480,7 @@ MENU smenu[] = {
   { TXT_SET_CLOCK, 3},
 #endif
 #if defined(ROTATION)
-  { XT_ROTATION, 7},
+  { TXT_ROTATION, 7},
 #endif
   { TXT_ABOUT, 10},
   { TXT_REBOOT, 98},
@@ -593,10 +584,10 @@ int rotation = 1;
     DISP.setTextSize(SMALL_TEXT);
     DISP.fillScreen(BGCOLOR);
     DISP.setCursor(0, 8, 1);
-    DISP.print("Battery: ");
+    DISP.print(TXT_BATT);
     DISP.print(battery);
     DISP.println("%");
-    DISP.println("Press any button to exit");
+    DISP.println(TXT_EXIT);
   }
 
   int get_battery_voltage() {
@@ -1311,9 +1302,9 @@ void aj_adv(){
     pAdvertising->setAdvertisementData(oAdvertisementData);
     pAdvertising->start();
 #if defined(M5LED)
-    digitalWrite(M5_LED_PIN, M5_LED_ON); //LED ON on Stick C Plus
+    digitalWrite(IRLED, LOW); //LED ON on Stick C Plus
     delay(10);
-     digitalWrite(M5_LED_PIN, M5_LED_OFF); //LED OFF on Stick C Plus
+     digitalWrite(IRLED, HIGH); //LED OFF on Stick C Plus
 #endif
   }
   if (check_next_press()) {
@@ -1420,9 +1411,9 @@ void wifispam_loop() {
   int i = 0;
   int len = 0;
 #if defined(M5LED)
-  digitalWrite(M5_LED_PIN, M5_LED_ON); //LED ON on Stick C Plus
+  digitalWrite(IRLED, LOW); //LED ON on Stick C Plus
   delay(1);
-  digitalWrite(M5_LED_PIN, M5_LED_OFF); //LED OFF on Stick C Plus
+  digitalWrite(IRLED, HIGH); //LED OFF on Stick C Plus
 #endif
   currentTime = millis();
   if (currentTime - attackTime > 100) {
@@ -1805,8 +1796,8 @@ void setup() {
   
   // Pin setup
 #if defined(M5LED)
-  pinMode(M5_LED_PIN, OUTPUT);
-  digitalWrite(M5_LED_PIN, M5_LED_OFF); //LEDOFF
+  pinMode(IRLED, OUTPUT);
+  digitalWrite(IRLED, M5_LED_OFF); //LEDOFF
 #endif
 #if !defined(KB)
   pinMode(M5_BUTTON_HOME, INPUT);

--- a/m5stick-nemo.ino
+++ b/m5stick-nemo.ino
@@ -40,6 +40,9 @@ String buildver="2.3.4";
   #define SD_CLK_PIN 0
   #define SD_MISO_PIN 36
   #define SD_MOSI_PIN 26
+  #define M5_LED_PIN 10
+  #define M5_LED_ON LOW
+  #define M5_LED_OFF HIGH
 #endif
 
 #if defined(STICK_C_PLUS2)
@@ -52,10 +55,12 @@ String buildver="2.3.4";
   #define TINY_TEXT 1
   // -=-=- FEATURES -=-=-
   //#define ACTIVE_LOW_IR
+  #define M5LED
   #define ROTATION
   #define USE_EEPROM
   //#define RTC      //TODO: plus2 has a BM8563 RTC but the class isn't the same, needs work.
   //#define SDCARD   //Requires a custom-built adapter
+  #define PWRMGMT
   // -=-=- ALIASES -=-=-
   #define DISP M5.Lcd
   #define IRLED 19
@@ -68,6 +73,10 @@ String buildver="2.3.4";
   #define SD_CLK_PIN 0
   #define SD_MISO_PIN 36
   #define SD_MOSI_PIN 26
+  #define BATTERY_MAX_VOLTAGE 3.7
+  #define M5_LED_PIN 19
+  #define M5_LED_ON HIGH
+  #define M5_LED_OFF LOW
 #endif
 
 #if defined(STICK_C)
@@ -92,6 +101,9 @@ String buildver="2.3.4";
   #define SD_CLK_PIN 0
   #define SD_MISO_PIN 36
   #define SD_MOSI_PIN 26
+  #define M5_LED_PIN 10
+  #define M5_LED_ON LOW
+  #define M5_LED_OFF HIGH
 #endif
 
 #if defined(CARDPUTER)
@@ -122,9 +134,10 @@ String buildver="2.3.4";
 #endif
 
 // -=-=-=-=-=- LIST OF CURRENTLY DEFINED FEATURES -=-=-=-=-=-
-// M5LED      - An LED exposed as M5_LED
+// M5LED      - An LED exposed as M5_LED_PIN
 // RTC        - Real-time clock exposed as M5.Rtc 
 // AXP        - AXP192 Power Management exposed as M5.Axp
+// PWRMGMT    - StickC+2 Power Management exposed as M5.Power
 // KB         - Keyboard exposed as M5Cardputer.Keyboard
 // HID        - HID exposed as USBHIDKeyboard
 // USE_EEPROM - Store settings in EEPROM
@@ -466,7 +479,7 @@ void dmenu_loop() {
 /// SETTINGS MENU ///
 MENU smenu[] = {
   { TXT_BACK, 1},
-#if defined(AXP)
+#if defined(AXP) || defined(PWRMGMT)
   { TXT_BATT_INFO, 6},
 #endif
 #if defined(CARDPUTER)
@@ -572,9 +585,56 @@ int rotation = 1;
   }
 #endif //ROTATION
 
-#if defined(AXP)
-  /// BATTERY INFO ///
-  int oldbattery=0;
+/// BATTERY INFO ///
+
+#if defined(PWRMGMT) && defined(BATTERY_MAX_VOLTAGE) 
+  int old_battery = 0;
+
+  void battery_drawmenu(int battery) {
+    DISP.setTextSize(SMALL_TEXT);
+    DISP.fillScreen(BGCOLOR);
+    DISP.setCursor(0, 8, 1);
+    DISP.print("Battery: ");
+    DISP.print(battery);
+    DISP.println("%");
+    DISP.println("Press any button to exit");
+  }
+
+  int get_battery_voltage() {
+    int current_voltage = M5.Power.getBatteryVoltage() / 1000;
+    int battery_percentage = (current_voltage / BATTERY_MAX_VOLTAGE) * 100;
+
+    if (battery_percentage > 100)
+      return 100;
+    if (battery_percentage < 0)
+      return 0;
+
+    return battery_percentage;
+  }
+
+  void battery_setup() {
+    int battery = get_battery_voltage();
+    battery_drawmenu(battery);
+    delay(500); // Prevent switching after menu loads up
+  }
+
+  void battery_loop() {
+    delay(300);
+    int battery = get_battery_voltage();
+
+    if (battery != old_battery){
+      battery_drawmenu(battery);
+    }
+    if (check_select_press()) {
+      isSwitching = true;
+      current_proc = 1;
+    }
+    old_battery = battery;
+  }
+#endif
+
+#ifdef AXP
+  int old_battery=0;
   void battery_drawmenu(int battery, int b, int c) {
     DISP.setTextSize(SMALL_TEXT);
     DISP.fillScreen(BGCOLOR);
@@ -589,6 +649,7 @@ int rotation = 1;
     DISP.println("");
     DISP.println(TXT_EXIT);
   }
+
   void battery_setup() {
     rstOverride = false;
     float c = M5.Axp.GetVapsData() * 1.4 / 1000;
@@ -603,15 +664,15 @@ int rotation = 1;
     float c = M5.Axp.GetVapsData() * 1.4 / 1000;
     float b = M5.Axp.GetVbatData() * 1.1 / 1000;
     int battery = ((b - 3.0) / 1.2) * 100;
-    if (battery != oldbattery){
+    if (battery != old_battery){
       battery_drawmenu(battery, b, c);
     }
     if (check_select_press()) {
       rstOverride = false;
       isSwitching = true;
-     current_proc = 1;
+      current_proc = 1;
     }
-    oldbattery = battery;
+    old_battery = battery;
   }
 #endif // AXP
 
@@ -1259,9 +1320,9 @@ void aj_adv(){
     pAdvertising->setAdvertisementData(oAdvertisementData);
     pAdvertising->start();
 #if defined(M5LED)
-    digitalWrite(M5_LED, LOW); //LED ON on Stick C Plus
+    digitalWrite(M5_LED_PIN, M5_LED_ON); //LED ON on Stick C Plus
     delay(10);
-     digitalWrite(M5_LED, HIGH); //LED OFF on Stick C Plus
+     digitalWrite(M5_LED_PIN, M5_LED_OFF); //LED OFF on Stick C Plus
 #endif
   }
   if (check_next_press()) {
@@ -1368,9 +1429,9 @@ void wifispam_loop() {
   int i = 0;
   int len = 0;
 #if defined(M5LED)
-  digitalWrite(M5_LED, LOW); //LED ON on Stick C Plus
+  digitalWrite(M5_LED_PIN, M5_LED_ON); //LED ON on Stick C Plus
   delay(1);
-  digitalWrite(M5_LED, HIGH); //LED OFF on Stick C Plus
+  digitalWrite(M5_LED_PIN, M5_LED_OFF); //LED OFF on Stick C Plus
 #endif
   currentTime = millis();
   if (currentTime - attackTime > 100) {
@@ -1753,8 +1814,8 @@ void setup() {
   
   // Pin setup
 #if defined(M5LED)
-  pinMode(M5_LED, OUTPUT);
-  digitalWrite(M5_LED, HIGH); //LEDOFF
+  pinMode(M5_LED_PIN, OUTPUT);
+  digitalWrite(M5_LED_PIN, M5_LED_OFF); //LEDOFF
 #endif
 #if !defined(KB)
   pinMode(M5_BUTTON_HOME, INPUT);
@@ -1817,7 +1878,7 @@ void loop() {
       case 5:
         tvbgone_setup();
         break;
-#if defined(AXP)
+#if defined(AXP) || defined(PWRMGMT)
       case 6:
         battery_setup();
         break;
@@ -1894,7 +1955,7 @@ void loop() {
     case 5:
       tvbgone_loop();
       break;
-#if defined(AXP)
+#if defined(AXP) || defined(PWRMGMT)
     case 6:
       battery_loop();
       break;

--- a/m5stick-nemo.ino
+++ b/m5stick-nemo.ino
@@ -8,7 +8,7 @@
 //#define CARDPUTER
 // -=-=- Uncommenting more than one at a time will result in errors -=-=-
 
-String buildver="2.3.4";
+String buildver="2.3.5";
 #define BGCOLOR BLACK
 #define FGCOLOR GREEN
 

--- a/portal.h
+++ b/portal.h
@@ -193,9 +193,9 @@ String clear_GET() {
 void blinkLed() {
   int count = 0;
   while (count < 5) {
-    digitalWrite(M5_LED, LOW);
+    digitalWrite(M5_LED_PIN, M5_LED_ON);
     delay(500);
-    digitalWrite(M5_LED, HIGH);
+    digitalWrite(M5_LED_PIN, M5_LED_OFF);
     delay(500);
     count = count + 1;
   }

--- a/portal.h
+++ b/portal.h
@@ -193,9 +193,9 @@ String clear_GET() {
 void blinkLed() {
   int count = 0;
   while (count < 5) {
-    digitalWrite(M5_LED_PIN, M5_LED_ON);
+    digitalWrite(IRLED, LOW);
     delay(500);
-    digitalWrite(M5_LED_PIN, M5_LED_OFF);
+    digitalWrite(IRLED, HIGH);
     delay(500);
     count = count + 1;
   }

--- a/portal.h
+++ b/portal.h
@@ -193,9 +193,9 @@ String clear_GET() {
 void blinkLed() {
   int count = 0;
   while (count < 5) {
-    digitalWrite(IRLED, LOW);
+    digitalWrite(IRLED, M5LED_ON);
     delay(500);
-    digitalWrite(IRLED, HIGH);
+    digitalWrite(IRLED, M5LED_OFF);
     delay(500);
     count = count + 1;
   }

--- a/songs.h
+++ b/songs.h
@@ -68,7 +68,7 @@ void setupSongs() {
 #if defined(STICK_C_PLUS)
     SPEAKER.tone(4000);
     delay(noteDuration * 0.9);
-    delay(noteDuration)
+    delay(noteDuration);
     SPEAKER.mute();
 #elif defined(CARDPUTER)
     // we only play the note for 90% of the duration, leaving 10% as a pause

--- a/tvbg.h
+++ b/tvbg.h
@@ -89,9 +89,9 @@ void delay_ten_us(uint16_t us) {
 
 void quickflashLED( void ) {
 #if defined(M5LED)
-  digitalWrite(M5_LED_PIN, M5_LED_ON);
+  digitalWrite(IRLED, LOW);
   delay_ten_us(3000);   // 30 ms ON-time delay
-  digitalWrite(M5_LED_PIN, M5_LED_OFF);
+  digitalWrite(IRLED, HIGH);
 #endif
 }
 

--- a/tvbg.h
+++ b/tvbg.h
@@ -89,9 +89,9 @@ void delay_ten_us(uint16_t us) {
 
 void quickflashLED( void ) {
 #if defined(M5LED)
-  digitalWrite(M5_LED, LOW);
+  digitalWrite(M5_LED_PIN, M5_LED_ON);
   delay_ten_us(3000);   // 30 ms ON-time delay
-  digitalWrite(M5_LED, HIGH);
+  digitalWrite(M5_LED_PIN, M5_LED_OFF);
 #endif
 }
 

--- a/tvbg.h
+++ b/tvbg.h
@@ -89,9 +89,9 @@ void delay_ten_us(uint16_t us) {
 
 void quickflashLED( void ) {
 #if defined(M5LED)
-  digitalWrite(IRLED, LOW);
+  digitalWrite(IRLED, M5LED_ON);
   delay_ten_us(3000);   // 30 ms ON-time delay
-  digitalWrite(IRLED, HIGH);
+  digitalWrite(IRLED, M5LED_OFF);
 #endif
 }
 


### PR DESCRIPTION
This PR adds the feature `PWRMGMT` to use `M5.Power` to get battery information for the M5Stickc plus2.
This also add/fix M5 LED for M5Stickc plus2.