### PR TITLE
fix: Theme not saving an rotatation

### DIFF
--- a/.github/workflows/dev_compile.yml
+++ b/.github/workflows/dev_compile.yml
@@ -189,45 +189,6 @@ jobs:
         with:
           name: M5Nemo-${{ matrix.board.name }}.${{ matrix.locale }}
           path: M5Nemo-*.bin
+          retention-days: 5
           if-no-files-found: error
 
-  create_release:
-    runs-on: ubuntu-latest
-    environment: github_release
-    needs: [compile_sketch]
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-
-    steps:
-    - id: nemo_version
-      name: Get NEMO Version
-      run: |
-        set -x
-
-        if [[ "${{ github.ref_type }}" == "tag" ]]; then
-          version=${{ github.ref_name }}
-        else
-          version="${GITHUB_SHA::7}"
-        fi
-
-        echo "version=${version}" > $GITHUB_OUTPUT
-
-    - uses: actions/download-artifact@v4
-      with:
-        merge-multiple: true
-
-    - name: List all files
-      if: always()
-      run: |
-        set -x
-        pwd
-        ls -all
-        tree
-
-    - name: Create Release ${{ steps.nemo_version.outputs.version }}
-      uses: softprops/action-gh-release@v1
-      with:
-        name: NEMO Release ${{ steps.nemo_version.outputs.version }}
-        tag_name: ${{ steps.nemo_version.outputs.version }}
-        generate_release_notes: true
-        files: |
-          M5Nemo-*.bin

--- a/m5stick-nemo.ino
+++ b/m5stick-nemo.ino
@@ -906,7 +906,7 @@ void theme_loop() {
 
 
 
-int rotation = 1;
+int rotation = EEPROM.read(0);
 #if defined(ROTATION)
   /// Rotation MENU ///
   MENU rmenu[] = {

--- a/m5stick-nemo.ino
+++ b/m5stick-nemo.ino
@@ -906,7 +906,7 @@ void theme_loop() {
 
 
 
-int rotation = EEPROM.read(0);
+int rotation = 0;
 #if defined(ROTATION)
   /// Rotation MENU ///
   MENU rmenu[] = {
@@ -934,12 +934,15 @@ int rotation = EEPROM.read(0);
       rstOverride = false;
       isSwitching = true;
       rotation = rmenu[cursor].command;
-      DISP.setRotation(rotation);
-      #if defined(USE_EEPROM)
-        EEPROM.write(0, rotation);
-        EEPROM.commit();
-      #endif
+      if (rotation>0) {
+        DISP.setRotation(rotation);
+        #if defined(USE_EEPROM)
+          EEPROM.write(0, rotation);
+          EEPROM.commit();
+        #endif
+      }
       current_proc = 2;
+
     }
   }
 #endif //ROTATION

--- a/m5stick-nemo.ino
+++ b/m5stick-nemo.ino
@@ -81,7 +81,7 @@ uint16_t FGCOLOR=0xFFF1; // placeholder
   #define SDCARD   //Requires a custom-built adapter
   #define PWRMGMT
   #define SPEAKER M5.Speaker
-  #define SONG
+  // #define SONG
   // -=-=- ALIASES -=-=-
   #define DISP M5.Lcd
   #define IRLED 19
@@ -814,6 +814,9 @@ void theme_setup() {
 }
 
 void theme_loop() {
+  int sfgcolor; //var to save the right number into eeprom
+  int sbgcolor; //var to save the right number into eeprom
+               //as it is saving uint16_t value to eeprom and getting wrong color on restart
   if (check_next_press()) {
     cursor++;
     cursor = cursor % thmenu_size;
@@ -863,6 +866,8 @@ void theme_loop() {
         BGCOLOR=1;
         break;
      }
+    sfgcolor=FGCOLOR;
+    sbgcolor=BGCOLOR;
     setcolor(true, FGCOLOR);
     setcolor(false, BGCOLOR);
     drawmenu(thmenu, thmenu_size);
@@ -887,9 +892,10 @@ void theme_loop() {
       default:
         #if defined(USE_EEPROM)
           Serial.printf("EEPROM WRITE (4) FGCOLOR: %d\n", FGCOLOR);
-          EEPROM.write(4, FGCOLOR);
+          EEPROM.write(4, sfgcolor);
           Serial.printf("EEPROM WRITE (5) BGCOLOR: %d\n", BGCOLOR);
-          EEPROM.write(5, BGCOLOR);
+          EEPROM.write(5, sbgcolor);
+          EEPROM.commit();
         #endif
         rstOverride = false;
         isSwitching = true;


### PR DESCRIPTION
# Minnor Fixes
* Fixed theme menu that wasn't saving configurations
* Disabled SONG for StickC Plus2 devices, to match with the other devices
* Fixed rotation menu, that was rotating when click in "back" btn
* Changed "dev_compile" workflow to not create release.


@vs4vijay I changed that "dev_compile" to not create releases, as i use it to build and test for all devices, didn't touch the compile one this tim!