### PR TITLE
fix: portal input truncation silently dropped, malloc null check, dead SD vars

### DIFF
--- a/m5stick-nemo.ino
+++ b/m5stick-nemo.ino
@@ -1783,6 +1783,7 @@ void aj_adv(){
       uint8_t display_name_len = strlen(display_name);
       uint8_t size = 7 + display_name_len;
       uint8_t* packet = (uint8_t*)malloc(size);
+      if (!packet) { free((void*)display_name); return; }
       uint8_t i = 0;
       packet[i++] = size - 1; // Size
       packet[i++] = 0xFF; // AD Type (Manufacturer Specific)
@@ -1794,12 +1795,10 @@ void aj_adv(){
       for (int j = 0; j < display_name_len; j++) {
         packet[i + j] = display_name[j];
       }
-      for (int i = 0; i < size; i ++) {
-        Serial.printf("%02x", packet[i]);
+      for (int k = 0; k < size; k++) {
+        Serial.printf("%02x", packet[k]);
       }
       Serial.println("");
-
-      i += display_name_len;  
       oAdvertisementData.addData(String((char *)packet, size));
       free(packet);
       free((void*)display_name);

--- a/portal.h
+++ b/portal.h
@@ -180,7 +180,7 @@ String getInputValue(String argName) {
   String a = webServer.arg(argName);
   a.replace("<", "&lt;");
   a.replace(">", "&gt;");
-  a.substring(0, 200);
+  a = a.substring(0, 200);
   return a;
 }
 

--- a/sd.h
+++ b/sd.h
@@ -122,8 +122,6 @@ bool setupSdCard() {
     {
       rstOverride = true;
       isSwitching = true;
-      uint8_t cardType = NULL;
-      uint64_t cardSize = NULL;
       current_proc=1;
       DISP.fillScreen(BGCOLOR);
       DISP.setCursor(5, 1);


### PR DESCRIPTION
## Summary

Three independent bugs found while reading the source:

**1. `portal.h` `getInputValue()` — input truncation never applied**

`a.substring(0, 200)` returns a new `String` and does not modify the original. The return value was discarded, so the 200-char cap the code intended to enforce never happened. Arbitrarily long user input was passed back to every captive-portal credential handler.

```cpp
// Before (truncation silently dropped):
a.substring(0, 200);
return a;

// After:
a = a.substring(0, 200);
return a;
```

**2. `m5stick-nemo.ino` SwiftPair `aj_adv()` — `malloc()` without null check**

`packet = malloc(size)` at the start of the SwiftPair branch had no null check. On allocation failure the immediately following `packet[i++] = ...` writes would crash. Added a guard that frees `display_name` and returns cleanly.

Also renamed the inner Serial debug loop variable from `i` to `k` to eliminate the shadowing that made the `i += display_name_len` line after it dead code.

**3. `sd.h` `ToggleSDCard()` — dead variables initialised with `NULL` on integer types**

`uint8_t cardType = NULL` and `uint64_t cardSize = NULL` at function scope were unreachable: both were immediately re-declared in every branch of the if/else below. `NULL` is a pointer constant and should not be used to initialise integer types (generates compiler warnings). Removed the two dead declarations.

## Test plan

- [ ] Captive portal: submit a credential longer than 200 chars — confirm it is truncated to 200 before storage
- [ ] SwiftPair: no functional change on normal hardware (allocation always succeeds); verifiable by code review
- [ ] SD toggle on non-Cardputer variant: mount/unmount still works, no regression

Generated with Claude Code