### PR TITLE
Add Glass2 secondary OLED display support for Cardputer builds

### DIFF
--- a/glass2.h
+++ b/glass2.h
@@ -1,0 +1,57 @@
+// glass2.h — M5Stack Glass2 Unit secondary display
+// 1.51" transparent OLED, SSD1309 driver, 128x64, I2C 0x3C
+// Grove port: SDA=GPIO2, SCL=GPIO1 (Cardputer ADV)
+//
+// Requires: Adafruit SSD1306 library (Arduino Library Manager)
+// SSD1309 is protocol-compatible with SSD1306 driver.
+//
+// Usage:
+//   glass2Init();          // call once in setup()
+//   glass2Show("MODE: KARMA", "SSID: Home...", "CLTS: 3", "CRED: 1");
+//   glass2Clear();         // blank the display
+
+#pragma once
+
+#include <Wire.h>
+#include <Adafruit_SSD1306.h>
+
+#define GLASS2_SDA    2
+#define GLASS2_SCL    1
+#define GLASS2_ADDR   0x3C
+#define GLASS2_WIDTH  128
+#define GLASS2_HEIGHT 64
+
+static Adafruit_SSD1306 _g2(GLASS2_WIDTH, GLASS2_HEIGHT, &Wire, -1);
+static bool _g2_ready = false;
+
+inline void glass2Init() {
+    Wire.begin(GLASS2_SDA, GLASS2_SCL);
+    _g2_ready = _g2.begin(SSD1306_SWITCHCAPVCC, GLASS2_ADDR);
+    if (_g2_ready) {
+        _g2.clearDisplay();
+        _g2.setTextColor(SSD1306_WHITE);
+        _g2.display();
+    }
+}
+
+// Show up to 4 lines. Pass nullptr to leave a line blank.
+inline void glass2Show(const char* l1,
+                       const char* l2 = nullptr,
+                       const char* l3 = nullptr,
+                       const char* l4 = nullptr) {
+    if (!_g2_ready) return;
+    _g2.clearDisplay();
+    _g2.setTextSize(1);
+    _g2.setTextColor(SSD1306_WHITE);
+    if (l1) { _g2.setCursor(0,  0); _g2.println(l1); }
+    if (l2) { _g2.setCursor(0, 16); _g2.println(l2); }
+    if (l3) { _g2.setCursor(0, 32); _g2.println(l3); }
+    if (l4) { _g2.setCursor(0, 48); _g2.println(l4); }
+    _g2.display();
+}
+
+inline void glass2Clear() {
+    if (!_g2_ready) return;
+    _g2.clearDisplay();
+    _g2.display();
+}

--- a/glass2.h
+++ b/glass2.h
@@ -2,35 +2,29 @@
 // 1.51" transparent OLED, SSD1309 driver, 128x64, I2C 0x3C
 // Grove port: SDA=GPIO2, SCL=GPIO1 (Cardputer ADV)
 //
-// Requires: Adafruit SSD1306 library (Arduino Library Manager)
-// SSD1309 is protocol-compatible with SSD1306 driver.
+// Requires: M5GFX (ships M5UnitGLASS2.h — already a dependency via M5Unified)
+// No additional library needed.
 //
 // Usage:
-//   glass2Init();          // call once in setup()
+//   glass2Init();
 //   glass2Show("MODE: KARMA", "SSID: Home...", "CLTS: 3", "CRED: 1");
-//   glass2Clear();         // blank the display
+//   glass2Clear();
 
 #pragma once
 
-#include <Wire.h>
-#include <Adafruit_SSD1306.h>
+#include <M5UnitGLASS2.h>
 
-#define GLASS2_SDA    2
-#define GLASS2_SCL    1
-#define GLASS2_ADDR   0x3C
-#define GLASS2_WIDTH  128
-#define GLASS2_HEIGHT 64
+#define GLASS2_SDA  2
+#define GLASS2_SCL  1
 
-static Adafruit_SSD1306 _g2(GLASS2_WIDTH, GLASS2_HEIGHT, &Wire, -1);
+static M5UnitGLASS2 _g2(GLASS2_SDA, GLASS2_SCL);
 static bool _g2_ready = false;
 
 inline void glass2Init() {
-    Wire.begin(GLASS2_SDA, GLASS2_SCL);
-    _g2_ready = _g2.begin(SSD1306_SWITCHCAPVCC, GLASS2_ADDR);
+    _g2_ready = _g2.init();
     if (_g2_ready) {
-        _g2.clearDisplay();
-        _g2.setTextColor(SSD1306_WHITE);
-        _g2.display();
+        _g2.fillScreen(TFT_BLACK);
+        _g2.setTextColor(TFT_WHITE, TFT_BLACK);
     }
 }
 
@@ -40,18 +34,16 @@ inline void glass2Show(const char* l1,
                        const char* l3 = nullptr,
                        const char* l4 = nullptr) {
     if (!_g2_ready) return;
-    _g2.clearDisplay();
+    _g2.fillScreen(TFT_BLACK);
     _g2.setTextSize(1);
-    _g2.setTextColor(SSD1306_WHITE);
-    if (l1) { _g2.setCursor(0,  0); _g2.println(l1); }
-    if (l2) { _g2.setCursor(0, 16); _g2.println(l2); }
-    if (l3) { _g2.setCursor(0, 32); _g2.println(l3); }
-    if (l4) { _g2.setCursor(0, 48); _g2.println(l4); }
-    _g2.display();
+    _g2.setTextColor(TFT_WHITE, TFT_BLACK);
+    if (l1) { _g2.setCursor(0,  0); _g2.print(l1); }
+    if (l2) { _g2.setCursor(0, 16); _g2.print(l2); }
+    if (l3) { _g2.setCursor(0, 32); _g2.print(l3); }
+    if (l4) { _g2.setCursor(0, 48); _g2.print(l4); }
 }
 
 inline void glass2Clear() {
     if (!_g2_ready) return;
-    _g2.clearDisplay();
-    _g2.display();
+    _g2.fillScreen(TFT_BLACK);
 }

--- a/m5stick-nemo.ino
+++ b/m5stick-nemo.ino
@@ -1992,6 +1992,18 @@ void wifispam_loop() {
       beaconSpamList(randoms);
       break;
   }
+#if defined(CARDPUTER)
+  {
+    static uint32_t _g2spam_t = 0;
+    uint32_t _now = millis();
+    if (_now - _g2spam_t >= 500) {
+      _g2spam_t = _now;
+      char l2[22];
+      snprintf(l2, sizeof(l2), "CH:%-2u PKT:%lu", (unsigned)wifi_channel, (unsigned long)packetCounter);
+      glass2Show("MODE: SPAM", l2, "", "");
+    }
+  }
+#endif
 }
 
 void btmaelstrom_setup(){
@@ -2799,6 +2811,14 @@ void deauth_hunter_loop() {
   draw_rssi_bar(deauth_stats.avg_rssi, dh_max_rssi);
   
   delay(100); // Refresh rate limiting
+#if defined(CARDPUTER)
+  {
+    char dl2[22], dl3[22];
+    snprintf(dl2, sizeof(dl2), "CH:%-2u APs:%-2u", (unsigned)WIFI_CHANNELS[current_channel_idx], (unsigned)deauth_stats.unique_aps);
+    snprintf(dl3, sizeof(dl3), "DEAUTH:%lu", (unsigned long)deauth_stats.total_deauths);
+    glass2Show("MODE: DEAUTH", dl2, dl3, "");
+  }
+#endif
 }
 
 ///////////////////////////////

--- a/m5stick-nemo.ino
+++ b/m5stick-nemo.ino
@@ -326,6 +326,7 @@ int dh_pkts = 0;
 #include "pineap_hunter.h"                                                          //PINEAP HUNTER
 #if defined(CARDPUTER)
 #include "badusb_hunter.h"                                                          //BADUSB HUNTER
+#include "glass2.h"                                                                 //GLASS2 OLED (Grove GPIO1/2)
 #endif
 struct MENU {
   char name[19];
@@ -1953,6 +1954,9 @@ void wifispam_setup() {
       break;
   }
   DISP.setTextSize(SMALL_TEXT);
+#if defined(CARDPUTER)
+  glass2Show("MODE: SPAM", "Beaconing...", "", "");
+#endif
   current_proc = 11;
 }
 
@@ -2314,6 +2318,9 @@ void portal_setup(){
   portal_active = true;
   cursor = 0;
   rstOverride = true;
+#if defined(CARDPUTER)
+  glass2Show("MODE: PORTAL", "Listening...", "", "");
+#endif
   printHomeToScreen();
   delay(500); // Prevent switching after menu loads up
 }
@@ -2437,6 +2444,10 @@ Serial.begin(115200);
   dimtimer();
   DISP.setRotation(rotation);
   DISP.setTextColor(FGCOLOR, BGCOLOR);
+#if defined(CARDPUTER)
+  glass2Init();
+  glass2Show("NEMO", "Ready", "", "");
+#endif
   bootScreen();
 }
 
@@ -2718,7 +2729,7 @@ void deauth_hunter_setup() {
   DISP.setTextSize(SMALL_TEXT);
   DISP.setTextColor(FGCOLOR, BGCOLOR);
   DISP.setCursor(0, 0);
-  
+
   // Initialize stats
   memset(&deauth_stats, 0, sizeof(DeauthStats));
   deauth_stats.avg_rssi = -90;
@@ -2726,6 +2737,9 @@ void deauth_hunter_setup() {
   current_channel_idx = 0;
   channel_hop_pause = false;
   start_deauth_monitoring();
+#if defined(CARDPUTER)
+  glass2Show("MODE: DEAUTH", "Hunting...", "", "");
+#endif
   delay(500);
 }
 


### PR DESCRIPTION
## Summary

Adds support for the [M5Stack Glass2 Unit](https://docs.m5stack.com/en/unit/Glass2%20Unit) (1.51" transparent OLED, SSD1309 driver, 128×64) as a secondary display when Nemo is running on an M5Stack Cardputer or Cardputer ADV.

- Adds `glass2.h` using **M5UnitGLASS2** from M5GFX — the official M5Stack driver, already a transitive dependency via M5Unified. No additional library required.
- All Glass2 code is inside `#if defined(CARDPUTER)` — zero impact on M5StickC, S3, or any other target
- `_g2_ready` flag makes all calls safe no-ops if no Glass2 is physically attached
- Grove GPIO1/2 are free on both Cardputer and Cardputer ADV (ADV's LoRa/GPS cap uses EXT header GPIO13/15, not Grove)

**Modes that update the Glass2:**

| Mode | Glass2 display |
|------|---------------|
| Startup | `NEMO / Ready` |
| WiFi Spam | `MODE: SPAM / Beaconing...` |
| Portal | `MODE: PORTAL / Listening...` |
| Deauth Hunter | `MODE: DEAUTH / Hunting...` |

## Test plan

- [ ] Compiles for all targets without errors (non-Cardputer targets unaffected)
- [ ] On Cardputer with Glass2 on Grove: startup splash shows, mode labels update on mode entry
- [ ] On Cardputer without Glass2: no crash, no change in behaviour (`_g2_ready` guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)