### PR TITLE
fix: SSID overflow, channel OOB, and menu cursor upper bound

### DIFF
--- a/m5stick-nemo.ino
+++ b/m5stick-nemo.ino
@@ -351,8 +351,9 @@ void drawmenu(MENU thismenu[], int size) {
   DISP.fillScreen(BGCOLOR);
   DISP.setCursor(0, 0, 1);
   // scrolling menu
+  if (cursor >= size) cursor = 0;
   if (cursor < 0) {
-    cursor = size - 1;  // rollover hack for up-arrow on cardputer  
+    cursor = size - 1;  // rollover hack for up-arrow on cardputer
   }
   if (cursor > 5) {
     for ( int i = 0 + (cursor - 5) ; i < size ; i++ ) {

--- a/portal.h
+++ b/portal.h
@@ -62,6 +62,9 @@ DNSServer dnsServer;
 WebServer webServer(80);
 
 void setSSID(String ssid){
+  if ((int)ssid.length() > apSsidMaxLen) {
+    ssid = ssid.substring(0, apSsidMaxLen);
+  }
   #if defined USE_EEPROM
   Serial.printf("Writing %d bytes of SSID to EEPROM\n", ssid.length());
   for(int i = 0; i < ssid.length(); i++) {

--- a/wifispam.h
+++ b/wifispam.h
@@ -190,7 +190,7 @@ void nextChannel() {
   if (sizeof(channels) > 1) {
     uint8_t ch = channels[channelIndex];
     channelIndex++;
-    if (channelIndex > sizeof(channels)) channelIndex = 0;
+    if (channelIndex >= sizeof(channels)) channelIndex = 0;
 
     if (ch != wifi_channel && ch >= 1 && ch <= 14) {
       wifi_channel = ch;


### PR DESCRIPTION
## Summary

Three independent safety fixes found during code review. All are edge-case crashes with no impact on normal operation.

- **portal.h — SSID buffer overflow**: `setSSID()` writes the SSID into EEPROM byte-by-byte with no length check. An SSID longer than `apSsidMaxLen` (32) would overflow the EEPROM region and corrupt adjacent stored data. Fixed by truncating the input string to `apSsidMaxLen` before writing.

- **wifispam.h — channel array OOB**: `nextChannel()` wraps `channelIndex` back to 0 when `channelIndex > sizeof(channels)`, but the wrap should trigger at `>=`. At exactly `sizeof(channels)` the index is already past the end of the array and `channels[channelIndex]` reads undefined memory before the wrap fires.

- **m5stick-nemo.ino — drawmenu cursor upper bound**: `drawmenu()` guards against `cursor < 0` but has no upper bound check. A stale `cursor` value ≥ `size` would cause `thismenu[cursor]` (and the loop index) to access past the end of the menu array. Added `if (cursor >= size) cursor = 0;` before the existing lower-bound guard.

## Test plan

- [ ] Build with PlatformIO — no new warnings or errors
- [ ] Set a portal SSID longer than 32 characters — truncated cleanly, no corruption
- [ ] Run beacon spam through a full channel cycle — no crash at channel wrap
- [ ] Navigate menu to last item and press down — wraps to first item without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)